### PR TITLE
Update docstring and adjust default behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,8 @@
 # SuperGrad: Differentiable Simulator for superconducting quantum processors
-<p align="center">
-  <!-- tests (GitHub actions) -->
-  <a href="https://github.com/iqubit-org/supergrad/actions/workflows/python-publish.yml">
-    <img src="https://img.shields.io/github/actions/workflow/status/iqubit-org/supergrad/python-publish.yml" />
-  </a>
-  <!-- docs -->
-  <a href="https://supergrad.readthedocs.io/">
-    <img src="https://img.shields.io/badge/docs-link-green.svg?logo=read-the-docs"/>
-  </a>
-  <!-- PyPI -->
-  <a href="https://pypi.org/project/supergrad/">
-    <img src="https://img.shields.io/pypi/v/supergrad.svg?logo=pypi"/>
-  </a>
-  <!-- License -->
-  <a href="./LICENSE">
-    <img src="https://img.shields.io/badge/license-Apache%202.0-blue.svg?logo=apache"/>
-  </a>
-</p>
+[![GitHub actions](https://img.shields.io/github/actions/workflow/status/iqubit-org/supergrad/python-publish.yml)](https://github.com/iqubit-org/supergrad/actions/workflows/python-publish.yml)
+[![Docs](https://img.shields.io/badge/docs-link-green.svg?logo=read-the-docs)](https://supergrad.readthedocs.io/)
+[![PyPI](https://img.shields.io/pypi/v/supergrad.svg?logo=pypi)](https://pypi.org/project/supergrad/)
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg?logo=apache)](https://github.com/iqubit-org/supergrad/blob/main/LICENSE)
 
 SuperGrad is an open-source simulator designed to accelerate the development of superconducting quantum processors by incorporating gradient computation capabilities.
 
@@ -59,11 +45,11 @@ H_{\mathrm{idle}}\left(\vec{h}\right)+\sum_{k=1}^{N_c}f_{k}\left(\vec{c},t\right
 ```
 
 The parameters about only a single qubit are stored in the nodes of the graph.
-These include parameters of superconducting qubits such as $`E_C`$, $`E_J`$, and parameters $`\vec{c}`$ of control pulses.
-The couplings of qubits are stored in the edges between qubits, which is a subset of $`\vec{h}`$.
-Then, some Helper classes will parse the graph, and create functions $`f(\vec{h},\vec{c})`$ which compute time-evolution unitary $`U(\vec{h},\vec{c})`$ or the energy spectrum of $`H_{\mathrm{idle}}(\vec{h})`$.
+These include parameters of superconducting qubits such as $E_C$, $E_J$, and parameters $\vec{c}$ of control pulses.
+The couplings of qubits are stored in the edges between qubits, which is a subset of $\vec{h}$.
+Then, some Helper classes will parse the graph, and create functions $f(\vec{h},\vec{c})$ which compute time-evolution unitary $U(\vec{h},\vec{c})$ or the energy spectrum of $H_{\mathrm{idle}}(\vec{h})$.
 One can construct objective functions based on these results.
-Jax can then be used to compute the gradient of an objective function and use it to run gradient optimization.
+JAX can then be used to compute the gradient of an objective function and use it to run gradient optimization.
 
 In general, we will use GHz and ns as units for energy and time parameters.
 
@@ -93,7 +79,7 @@ H_{ij} = J_{\mathrm{C}} n_i n_j - J_{\mathrm{L}} \varphi_i \varphi_j
 The couplings are chosen in a way such that the idling $`ZZ`$-crosstalk is almost zero.
 We compute the time-evolution and the Pauli error rates for
 simultaneous single-qubit X gates and two-qubit CR gates.
-More details can be found in a future paper.
+More details can be found in [Ni, X. et al. Superconducting processor design optimization for quantum error correction performance. arXiv:2312.04186](https://arxiv.org/pdf/2312.04186).
 
 ### Transmon with tunable couplers
 
@@ -109,13 +95,13 @@ Here we try to infer the parameters of the system from spectrum data from experi
 We will consider the simplest case which is fitting the parameters of one Fluxonium.
 But the procedure can be applied to more complex systems as well.
 
-### Citation
+## Citation
 
 If this project is helpful to you in your research, the use of SuperGrad in research publications is appropriately acknowledged by citing:
 
 ```
 @misc{supergrad_2024,
-      title={SuperGrad: a differentiable simulator for superconducting processors}, 
+      title={SuperGrad: a differentiable simulator for superconducting processors},
       author={Ziang Wang and Feng Wu and Hui-Hai Zhao and Xin Wan and Xiaotong Ni},
       year={2024},
       eprint={2406.18155},

--- a/supergrad/scgraph/graph.py
+++ b/supergrad/scgraph/graph.py
@@ -250,9 +250,11 @@ class SCGraph(nx.Graph):
         for edge in self.sorted_edges:
             q1, q2 = edge
             attr = graph.edges[edge]
-            nodes_pair = sorted([q1, q2])
-            edge_type = tuple(graph.nodes[node].get('shared_param_mark', node)
-                              for node in nodes_pair)
+            edge_type = tuple(
+                sorted([
+                    graph.nodes[node].get('shared_param_mark', node)
+                    for node in [q1, q2]
+                ]))
             for k, v in dict(attr).items():
                 if unify_coupling:
                     key = _parse_edges_name(k, 'all', 'unify')
@@ -338,10 +340,11 @@ class SCGraph(nx.Graph):
         for edge in self.sorted_edges:
             q1, q2 = edge
             attr = EdgeView(self)[edge]
-            nodes_pair = sorted([q1, q2])
             edge_type = tuple(
-                NodeView(self)[node].get('shared_param_mark', node)
-                for node in nodes_pair)
+                sorted([
+                    NodeView(self)[node].get('shared_param_mark', node)
+                    for node in [q1, q2]
+                ]))
             idx_q1 = subsystem_name_list.index(q1)
             idx_q2 = subsystem_name_list.index(q2)
             if unify_coupling:
@@ -510,10 +513,11 @@ class SCGraph(nx.Graph):
                                 }
                             })
                     else:
-                        nodes_pair = sorted([q1, q2])
                         edge_type = tuple(
-                            NodeView(self)[node].get('shared_param_mark', node)
-                            for node in nodes_pair)
+                            sorted(
+                                NodeView(self)[node].get(
+                                    'shared_param_mark', node)
+                                for node in [q1, q2]))
                         try:
                             edge_type_dict[edge_type].update({coupling_name: v})
                         except KeyError:
@@ -534,10 +538,11 @@ class SCGraph(nx.Graph):
             # update graph edges parameters
             for edge in EdgeView(self):
                 q1, q2 = edge
-                nodes_pair = sorted([q1, q2])
                 edge_type = tuple(
-                    NodeView(self)[node].get('shared_param_mark', node)
-                    for node in nodes_pair)
+                    sorted([
+                        NodeView(self)[node].get('shared_param_mark', node)
+                        for node in [q1, q2]
+                    ]))
                 # update interaction
                 try:
                     if unify_coupling:

--- a/supergrad/time_evolution/ode.py
+++ b/supergrad/time_evolution/ode.py
@@ -41,7 +41,7 @@ def ode_expm(func,
              astep=100,
              trotter_order=None,
              progress_bar=False,
-             custom_vjp=None,
+             custom_vjp=True,
              pb_fwd_ad=False,
              compatibility_mode=False):
     """ODE solver using the matrix exponentiation for the propagators at each time
@@ -76,8 +76,8 @@ def ode_expm(func,
         pb_fwd_ad (bool) : whether to config progress bar as forward mode
             automatic differentiation.
         compatibility_mode (bool) : whether to use the compatible mode for `func`.
-            We disable compatible mode for the quantum system, where the evolution
-            operator is not depend on `y`, so we could pass 0 to the `func` directly.
+            We disable compatible mode to reduce computational cost when the evolution
+            operator is not depend on `y`, so we could let `y` equals to 0 in the `func`.
 
 
     Returns:

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -47,7 +47,7 @@ def graph_to_quantum_system(graph: SCGraph = graph,
 def test_sharing_parameters():
     hk_0, params_0 = graph_to_quantum_system(share_params=False)
     hk_1, params_1 = graph_to_quantum_system(share_params=True)
-    assert len(hk_0) - len(hk_1) == 80
+    assert len(hk_0) - len(hk_1) == 100
     assert np.allclose(tree_leaves(params_0), tree_leaves(params_1))
 
 
@@ -56,7 +56,7 @@ def test_enable_deviations():
     hk_1, params_1 = graph_to_quantum_system(add_random=True,
                                              share_params=False)
     hk_2, params_2 = graph_to_quantum_system(add_random=True, share_params=True)
-    assert len(hk_1) - len(hk_2) == 80
+    assert len(hk_1) - len(hk_2) == 100
     assert len(hk_0) == len(hk_1)
     assert np.allclose(tree_leaves(params_1), tree_leaves(params_2))
     assert np.allclose(tree_leaves(params_0), tree_leaves(params_2), rtol=0.05)


### PR DESCRIPTION
- Adjust default argument for `ode_expm`
We notice the cost of 6-qubit examples may be beyond the laptop's memory limitation. It's valuable to adjust SuperGrad default back-propagation behavior from auto-diff to the local continuous adjoint method.
- Some updates to docstring.
- Fix bug about sharing parameters between the couplings.