### PR TITLE
Fix parameter type and graph exception bug

### DIFF
--- a/supergrad/scgraph/graph.py
+++ b/supergrad/scgraph/graph.py
@@ -600,7 +600,7 @@ class SCGraph(nx.Graph):
                             list(edge_type_dict.values())[0])
                     else:
                         EdgeView(self)[edge].update(edge_type_dict[edge_type])
-                except KeyError and IndexError:
+                except (KeyError, IndexError):
                     warnings.warn(
                         f'The parameters dictionary does not contain edges '
                         f'type {edge_type}, keeping edge {edge} unchanged.')

--- a/supergrad/scgraph/graph_mpc_fluxonium_1d.py
+++ b/supergrad/scgraph/graph_mpc_fluxonium_1d.py
@@ -158,9 +158,9 @@ class MPCFluxonium1D(SCGraph):
         return dic2
 
     def create_cr_pulse(self,
-                        ix_control_list: int,
-                        ix_target_list: int,
-                        tg_list: int,
+                        ix_control_list: list[int],
+                        ix_target_list: list[int],
+                        tg_list: list[float],
                         add_random: bool,
                         ar_crosstalk=None,
                         pulse_type: str = "cos",
@@ -260,8 +260,8 @@ class MPCFluxonium1D(SCGraph):
         return transform_matrix
 
     def create_single_qubit_pulse(self,
-                                  ix_qubit_list: int,
-                                  tg_list: int,
+                                  ix_qubit_list: list[int],
+                                  tg_list: list[float],
                                   add_random: bool,
                                   ar_crosstalk=None,
                                   factor=0.5,


### PR DESCRIPTION
### Summary

This PR fixes two bugs:
1. Several annotations in `graph_mpc_fluxonium_1d.py` were incorrect. They are of type `list`, not `int`.
2. In graph.py, when trying to catch different types of exceptions, the syntax was incorrect. In Python, we can't use `and` to combine exception types in an except clause. The correct syntax should be `except (KeyError, IndexError):` with parentheses and commas.


### Testing
Jupyter notebook scripts such as `fluxonium_mpcoupling_6q_x.ipynb` still work.