### PR TITLE
Fix failed unit test by pinning qiskit verison <2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     extras_require={
         # Used for benchmark
         'benchmark': [
-            'qiskit_dynamics', 'qutip', 'pytest', 'pytest-benchmark',
+            'qiskit_dynamics', 'qiskit<2.0', 'qutip', 'pytest', 'pytest-benchmark',
             'scqubits', 'psutil'
         ],
         'docs': ['qutip', 'qutip-qip'],


### PR DESCRIPTION
### Summary

The unit test was consistently failing in the last few commits: https://github.com/iqubit-org/supergrad/actions/workflows/ci-test.yml

Error log:
```
==================================== ERRORS ====================================
_____________ ERROR collecting benchmark/test_comparison_exists.py _____________
ImportError while importing test module '/home/runner/work/supergrad/supergrad/benchmark/test_comparison_exists.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/opt/hostedtoolcache/Python/3.11.13/x64/lib/python3.11/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
benchmark/test_comparison_exists.py:12: in <module>
    from qiskit_dynamics import Solver
test_env/lib/python3.11/site-packages/qiskit_dynamics/__init__.py:38: in <module>
    from .solvers.solver_functions import solve_ode, solve_lmde
test_env/lib/python3.11/site-packages/qiskit_dynamics/solvers/__init__.py:111: in <module>
    from .solver_classes import Solver
test_env/lib/python3.11/site-packages/qiskit_dynamics/solvers/solver_classes.py:29: in <module>
    from qiskit.pulse import Schedule, ScheduleBlock
E   ModuleNotFoundError: No module named 'qiskit.pulse'
```

The root cause:
Dependency `qiskit_dynamics` version `0.5.1` pulls `qiskit-2.1.2` transitively. Starting from qiskit 2.0, code module `qiskit.pulse` has been removed, but `qiskit_dynamics` still has certain part of code which imports `qiskit.pulse`. To fix this problem, we need to pin `qiskit` to a version `<2.0` explicitly. 


### Testing
Unit tests can pass now: 
https://github.com/iqubit-org/supergrad/actions/runs/17534857161/job/49796572860